### PR TITLE
Remove pycache from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+__pycache__/


### PR DESCRIPTION
Hi,
great work!

Pycache stores temporary files created when execution of the python code is triggered.
It is not meant to be distributed, so is better to remove from the repo.

Andrea Garritano

